### PR TITLE
Feature: stdoutを構造化する

### DIFF
--- a/scratch/rl-tcp/test_tcp.py
+++ b/scratch/rl-tcp/test_tcp.py
@@ -14,36 +14,43 @@ __email__ = "gawlowicz@tkn.tu-berlin.de"
 
 
 logging.basicConfig(
-    format='%(asctime)s %(levelname)-8s %(message)s',
+    format="%(asctime)s %(levelname)-8s %(message)s",
     level=logging.INFO,
-    datefmt='%Y-%m-%d %H:%M:%S',
-    filename='output.log',
-    filemode='w'
+    datefmt="%Y-%m-%d %H:%M:%S",
+    filename="output.log",
+    filemode="w",
 )
 
-parser = argparse.ArgumentParser(description='Start simulation script on/off')
-parser.add_argument('--start',
-                    type=int,
-                    default=1,
-                    help='Start ns-3 simulation script 0/1, Default: 1')
-parser.add_argument('--iterations',
-                    type=int,
-                    default=1,
-                    help='Number of iterations, Default: 1')
+parser = argparse.ArgumentParser(description="Start simulation script on/off")
+parser.add_argument(
+    "--start", type=int, default=1, help="Start ns-3 simulation script 0/1, Default: 1"
+)
+parser.add_argument(
+    "--iterations", type=int, default=1, help="Number of iterations, Default: 1"
+)
 args = parser.parse_args()
 startSim = bool(args.start)
 iterationNum = int(args.iterations)
 
 port = 5555
-simTime = 10 # seconds
+simTime = 10  # seconds
 stepTime = 0.5  # seconds
 seed = 12
-simArgs = {"--duration": simTime,}
+simArgs = {
+    "--duration": simTime,
+}
 debug = False
 
-env = ns3env.Ns3Env(port=port, stepTime=stepTime, startSim=startSim, simSeed=seed, simArgs=simArgs, debug=debug)
+env = ns3env.Ns3Env(
+    port=port,
+    stepTime=stepTime,
+    startSim=startSim,
+    simSeed=seed,
+    simArgs=simArgs,
+    debug=debug,
+)
 # simpler:
-#env = ns3env.Ns3Env()
+# env = ns3env.Ns3Env()
 env.reset()
 
 ob_space = env.observation_space
@@ -53,6 +60,7 @@ logging.info("Action space: %s, %s", ac_space, ac_space.dtype)
 
 stepIdx = 0
 currIt = 0
+
 
 def get_agent(obs):
     socketUuid = obs[0]
@@ -69,6 +77,7 @@ def get_agent(obs):
         get_agent.tcpAgents[socketUuid] = tcpAgent
 
     return tcpAgent
+
 
 # initialize variable
 get_agent.tcpAgents = {}
@@ -93,7 +102,9 @@ try:
 
             obs, reward, done, info = env.step(action)
             logging.info("Step: %s", stepIdx)
-            logging.info("obs: %s, reward: %s, done: %s, info: %s", obs, reward, done, info)
+            logging.info(
+                "obs: %s, reward: %s, done: %s, info: %s", obs, reward, done, info
+            )
 
             # get existing agent of create new TCP agent if needed
             tcpAgent = get_agent(obs)

--- a/scratch/rl-tcp/test_tcp.py
+++ b/scratch/rl-tcp/test_tcp.py
@@ -2,6 +2,7 @@
 # -*- coding: utf-8 -*-
 
 import argparse
+import logging
 from ns3gym import ns3env
 from tcp_base import TcpTimeBased
 from tcp_newreno import TcpNewReno
@@ -11,6 +12,14 @@ __copyright__ = "Copyright (c) 2018, Technische Universität Berlin"
 __version__ = "0.1.0"
 __email__ = "gawlowicz@tkn.tu-berlin.de"
 
+
+logging.basicConfig(
+    format='%(asctime)s %(levelname)-8s %(message)s',
+    level=logging.INFO,
+    datefmt='%Y-%m-%d %H:%M:%S',
+    filename='output.log',
+    filemode='w'
+)
 
 parser = argparse.ArgumentParser(description='Start simulation script on/off')
 parser.add_argument('--start',
@@ -39,8 +48,8 @@ env.reset()
 
 ob_space = env.observation_space
 ac_space = env.action_space
-print("Observation space: ", ob_space,  ob_space.dtype)
-print("Action space: ", ac_space, ac_space.dtype)
+logging.info("Observation space: %s, %s", ob_space, ob_space.dtype)
+logging.info("Action space: %s, %s", ac_space, ac_space.dtype)
 
 stepIdx = 0
 currIt = 0
@@ -67,14 +76,12 @@ get_agent.ob_space = ob_space
 get_agent.ac_space = ac_space
 
 try:
+    print("step,ssThresh,windowSize")
     while True:
-        print("Start iteration: ", currIt)
         obs = env.reset()
         reward = 0
         done = False
         info = None
-        print("Step: ", stepIdx)
-        print("---obs: ", obs)
 
         # get existing agent of create new TCP agent if needed
         tcpAgent = get_agent(obs)
@@ -82,11 +89,11 @@ try:
         while True:
             stepIdx += 1
             action = tcpAgent.get_action(obs, reward, done, info)
-            print("---action: ", action)
+            print(f"{stepIdx},{action[0]},{action[1]}")
 
-            print("Step: ", stepIdx)
             obs, reward, done, info = env.step(action)
-            print("---obs, reward, done, info: ", obs, reward, done, info)
+            logging.info("Step: %s", stepIdx)
+            logging.info("obs: %s, reward: %s, done: %s, info: %s", obs, reward, done, info)
 
             # get existing agent of create new TCP agent if needed
             tcpAgent = get_agent(obs)
@@ -102,7 +109,7 @@ try:
             break
 
 except KeyboardInterrupt:
-    print("Ctrl-C -> Exit")
+    logging.warn("Ctrl-C received, exiting...")
 finally:
     env.close()
-    print("Done")
+    logging.info("Simulation done.")


### PR DESCRIPTION
## WHY

ns3のシミュレーション結果が以下のようになっていた．今までは，輻輳ウインドウサイズなどを抽出するために，正規表現などを駆使して頑張っていたが，そもそもの出力形式を変えた方が早そうだし，その他の解析をする際なども色々嬉しそうだった

```text
Observation space:  Box(0, 1000000000, (15,), uint64) uint64
Action space:  Box(0, 65535, (2,), uint64) uint64
Start iteration:  0
Step:  0
---obs:  [         1          0     163241          2 4294967295        340
        340          1 3985472720      80375      80000          1
          0          0          0]
---action:  [1700, 3400]
Step:  1
---obs, reward, done, info:  [         1          0     247346          2 4294967295       3400
```

## WHAT

test_tcp.py の出力を構造化した．より正確には，csvとして有効になるように変更し，合わせてそのほかの出力はデバッグ時に触れるように `output.log` にログ出力させるようにした．

つまり，手元では以下のように出力されるようにした．

ビルドして実行．

```bash
$ pwd
# path/to/ns3-gym
$ docker image build -t gym-debug .   
$ docker container run --rm gym-debug > out.csv
```

結果を見る

```bash
$ head out.csv                                 
step,ssThresh,windowSize
1,1685511784,680
2,1685511784,1020
3,1685511784,1360
4,1685511784,1700
5,1685511784,2040
6,1685511784,2380
7,1685511784,2720
8,1685511784,3060
9,1685511784,3400
```