### PR TITLE
update: シミュレーションの環境を変更

### DIFF
--- a/scratch/rl-tcp/sim.cc
+++ b/scratch/rl-tcp/sim.cc
@@ -91,7 +91,7 @@ void TraceThroughput(Ptr<Application> app, Ptr<OutputStreamWrapper> stream, doub
 int main (int argc, char *argv[])
 {
   uint32_t openGymPort = 5555;
-  double tcpEnvTimeStep = 0.1;
+  double tcpEnvTimeStep = 0.01;
 
   uint32_t nLeaf = 1;
   std::string transport_prot = "TcpRl";
@@ -114,7 +114,7 @@ int main (int argc, char *argv[])
   // required parameters for OpenGym interface
   cmd.AddValue ("openGymPort", "Port number for OpenGym env. Default: 5555", openGymPort);
   cmd.AddValue ("simSeed", "Seed for random generator. Default: 1", run);
-  cmd.AddValue ("envTimeStep", "Time step interval for time-based TCP env [s]. Default: 0.1s", tcpEnvTimeStep);
+  cmd.AddValue ("envTimeStep", "Time step interval for time-based TCP env [s]. Default: 0.01s", tcpEnvTimeStep);
   // other parameters
   cmd.AddValue ("nLeaf",     "Number of left and right side leaf nodes", nLeaf);
   cmd.AddValue ("transport_prot", "Transport protocol to use: TcpNewReno, "

--- a/scratch/rl-tcp/test_tcp.py
+++ b/scratch/rl-tcp/test_tcp.py
@@ -33,7 +33,7 @@ startSim = bool(args.start)
 iterationNum = int(args.iterations)
 
 port = 5555
-simTime = 10  # seconds
+simTime = 20  # seconds
 stepTime = 0.5  # seconds
 seed = 12
 simArgs = {


### PR DESCRIPTION
## Change List

1. シミュレーションの実行時間を10->20secに変更
2. スループットの計測間隔を0.1->0.01secに変更

## 作業ログ

```bash
junyaokabe@JunyanoMacBook-Pro: ~/workspace/poet-infra (main =) $ docker container ls -a | grep ns3-gym | awk '{print $1}'
d64b4b854d3e
junyaokabe@JunyanoMacBook-Pro: ~/workspace/poet-infra (main =) $ docker cp d64b4b854d3e:/ns3-gym/scratch/rl-tcp/throughput.csv ./tmp.csv
Successfully copied 29.7kB to /Users/junyaokabe/workspace/poet-infra/tmp.csv
junyaokabe@JunyanoMacBook-Pro: ~/workspace/poet-infra (main %=) $ tail tmp.csv
20, 1593.75
20.01, 1859.38
20.02, 1593.75
20.03, 1593.75
20.04, 1859.38
20.05, 1593.75
20.06, 1593.75
20.07, 1859.38
20.08, 1593.75
20.09, 1593.75
```