### PR TITLE
feat: set limitation of action value

### DIFF
--- a/scratch/rl-tcp/test_tcp.py
+++ b/scratch/rl-tcp/test_tcp.py
@@ -100,6 +100,10 @@ try:
         while True:
             stepIdx += 1
             action = tcpAgent.get_action(obs, reward, done, info)
+            if int(action[0]) >= 3 * 10 ** 6:
+                action[0] = 3 * 10 ** 6 - 1
+            if int(action[2]) >= 3 * 10 ** 6:
+                action[2] = 3 * 10 ** 6 - 1
             print(f"{stepIdx},{action[0]},{action[1]}")
 
             obs, reward, done, info = env.step(action)


### PR DESCRIPTION
## 背景

ssThresh の値が上限 (== 2**32-1) になることが多数発生した。これは int 型の上限で、long 使うなど誤魔化しは効くものの、大変になるので、天井を設定して無理やり抑えることに決めた

## やった

上限設定をやった
